### PR TITLE
CI: Build against 3.7 and intake master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: xenial  # for Python 3.7
 language: python
 matrix:
+  fast_finish: true
   include:
   - python: 3.6
     env: INTAKE_MASTER=false
@@ -8,6 +9,10 @@ matrix:
     env: INTAKE_MASTER=false
   - python: 3.7
     env: INTAKE_MASTER=true
+  - python: nightly
+  allow_failures:
+    - python: nightly
+    - env: INTAKE_MASTER=true
 cache:
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ matrix:
       apt:
         packages:
           - libhdf5-serial-dev
-          - netcdf-bin
           - libnetcdf-dev
+          - libsnappy-dev
+          - netcdf-bin
   allow_failures:
     - python: nightly
     - env: INTAKE_MASTER=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
+dist: xenial  # for Python 3.7
 language: python
-python:
-  - 3.6
+matrix:
+  include:
+  - python: 3.6
+    env: INTAKE_MASTER=false
+  - python: 3.7
+    env: INTAKE_MASTER=false
+  - python: 3.7
+    env: INTAKE_MASTER=true
 cache:
   directories:
     - $HOME/.cache/pip
@@ -24,6 +31,11 @@ install:
   - pip install .
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
+  # Install intake master branch if build settings indicate to do so.
+  - |
+    if [ "$INTAKE_MASTER" = true ] ; then
+      pip install git+https://github.com/intake/intake@master
+    fi
 
 script:
   - coverage run -m pytest  # Run the tests and check for test coverage.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ matrix:
     env: INTAKE_MASTER=true
   - python: nightly
     env: INTAKE_MASTER=false
+    addons:
+      apt:
+        packages:
+          - libhdf5-serial-dev
+          - netcdf-bin
+          - libnetcdf-dev
   allow_failures:
     - python: nightly
     - env: INTAKE_MASTER=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   - python: 3.7
     env: INTAKE_MASTER=true
   - python: nightly
+    env: INTAKE_MASTER=false
   allow_failures:
     - python: nightly
     - env: INTAKE_MASTER=true


### PR DESCRIPTION
We currently build against Python 3.6 only. In this PR, I add:

- one build against Python 3.7
- a second build against Python 3.7 with intake's `master` branch
- a build against Python "nightly"

I have set up a nightly Travis-CI Cron Job, so we should know within a day if intake upstream or Python upstream makes a change that breaks our test suite.

The builds are configured such that the latter two fail, the build "passes" (such failures against unstable dependencies should not block merging PRs).