### PR TITLE
API: Rename RunCatalog->BlueskyRun.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,23 +27,23 @@ implemented, intake may obtain a Catalog's length by iterating through it
 entirely, which may be costly. If a more efficient approach is possible (e.g. a
 COUNT query) it should be implemented.
 
-Integration with RunCatalog
+Integration with BlueskyRun
 ---------------------------
 
 For each file format / backend (MongoDB, newline-delimited JSON, directory of
 TIFFs, etc.) one needs to write a single custom catalog. Its entries, created
 dynamically as described above, should be ``LocalCatalogEntry`` objects that
-identify ``intake_bluesky.core.RunCatalog`` as their driver. See below for the
+identify ``intake_bluesky.core.BlueskyRun`` as their driver. See below for the
 arguments that they would provide to the entry so that it can instantiate the
 catalog when called upon.
 
 Core
 ====
 
-.. autoclass:: intake_bluesky.core.RunCatalog
+.. autoclass:: intake_bluesky.core.BlueskyRun
    :members:
 
-.. autoclass:: intake_bluesky.core.RemoteRunCatalog
+.. autoclass:: intake_bluesky.core.RemoteBlueskyRun
    :members:
 
 .. autoclass:: intake_bluesky.core.BlueskyEventStream

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,14 +23,14 @@ bluesky.
   instead of performing plain-text search.
 * Intake-Bluesky ships Catalogs that embody the semantics of bluesky's data
   model. A bluesky "run" (e.g. one scan) is represented by a
-  :class:`~intake_bluesky.core.RunCatalog`.  Each logical table of data within
+  :class:`~intake_bluesky.core.BlueskyRun`.  Each logical table of data within
   a given run is represented by a
   :class:`~intake_bluesky.core.BlueskyEventStream`.
 * The methods :meth:`~intake_bluesky.core.BlueskyEventStream.read()` and
   :meth:`~intake_bluesky.core.BlueskyEventStream.to_dask()` provide the data in
   SciPy/PyData structures and their "lazy" dask-backed counterparts, as with
   any other intake data source.
-* The additional method :meth:`~intake_bluesky.core.RunCatalog.read_canonical`
+* The additional method :meth:`~intake_bluesky.core.BlueskyRun.read_canonical`
   returns a generator suitable for streaming. Its elements satisfy
   `bluesky's data model <https://nsls-ii.github.io/event-model>`_ and can be
   fed into streaming visualization, processing, and serialization tools that
@@ -56,7 +56,7 @@ Intake-Bluesky will also address the use case of reading files *not* produced
 by bluesky, retrofitting the semantics of its data model. Thus, a "bucket
 of files" such as a directory of TIFFs could be fed through tools that consume
 the representation returned by
-:meth:`~intake_bluesky.core.RunCatalog.read_canonical`.
+:meth:`~intake_bluesky.core.BlueskyRun.read_canonical`.
 
 .. note::
 

--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -189,11 +189,11 @@ def documents_to_xarray(*, start_doc, stop_doc, descriptor_docs, event_docs,
     return xarray.merge(datasets)
 
 
-class RemoteRunCatalog(intake.catalog.base.RemoteCatalog):
+class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
     """
     Catalog representing one Run.
 
-    This is a client-side proxy to a RunCatalog stored on a remote server.
+    This is a client-side proxy to a BlueskyRun stored on a remote server.
 
     Parameters
     ----------
@@ -259,12 +259,12 @@ class RemoteRunCatalog(intake.catalog.base.RemoteCatalog):
 
     def read(self):
         raise NotImplementedError(
-            "Reading the RunCatalog itself is not supported. Instead read one "
+            "Reading the BlueskyRun itself is not supported. Instead read one "
             "its entries, representing individual Event Streams.")
 
     def to_dask(self):
         raise NotImplementedError(
-            "Reading the RunCatalog itself is not supported. Instead read one "
+            "Reading the BlueskyRun itself is not supported. Instead read one "
             "its entries, representing individual Event Streams.")
 
     def _close(self):
@@ -295,7 +295,7 @@ class RemoteRunCatalog(intake.catalog.base.RemoteCatalog):
         raise NotImplementedError("Cannot search within one run.")
 
 
-class RunCatalog(intake.catalog.Catalog):
+class BlueskyRun(intake.catalog.Catalog):
     """
     Catalog representing one Run.
 
@@ -483,12 +483,12 @@ class RunCatalog(intake.catalog.Catalog):
 
     def read(self):
         raise NotImplementedError(
-            "Reading the RunCatalog itself is not supported. Instead read one "
+            "Reading the BlueskyRun itself is not supported. Instead read one "
             "its entries, representing individual Event Streams.")
 
     def to_dask(self):
         raise NotImplementedError(
-            "Reading the RunCatalog itself is not supported. Instead read one "
+            "Reading the BlueskyRun itself is not supported. Instead read one "
             "its entries, representing individual Event Streams.")
 
 
@@ -689,5 +689,5 @@ def parse_handler_registry(handler_registry):
     return result
 
 
-intake.registry['remote-bluesky-run-catalog'] = RemoteRunCatalog
-intake.container.container_map['bluesky-run-catalog'] = RemoteRunCatalog
+intake.registry['remote-bluesky-run-catalog'] = RemoteBlueskyRun
+intake.container.container_map['bluesky-run-catalog'] = RemoteBlueskyRun

--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -209,7 +209,7 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
         Additional info
     kwargs: ignored
     """
-    name = 'bluesky-run-catalog'
+    name = 'bluesky-run'
 
     def __init__(self, url, http_args, name, parameters, metadata=None, **kwargs):
         super().__init__(url=url, http_args=http_args, name=name,
@@ -322,7 +322,7 @@ class BlueskyRun(intake.catalog.Catalog):
         Additional keyword arguments are passed through to the base class,
         Catalog.
     """
-    container = 'bluesky-run-catalog'
+    container = 'bluesky-run'
     version = '0.0.1'
     partition_access = True
     PARTITION_SIZE = 100
@@ -689,5 +689,5 @@ def parse_handler_registry(handler_registry):
     return result
 
 
-intake.registry['remote-bluesky-run-catalog'] = RemoteBlueskyRun
-intake.container.container_map['bluesky-run-catalog'] = RemoteBlueskyRun
+intake.registry['remote-bluesky-run'] = RemoteBlueskyRun
+intake.container.container_map['bluesky-run'] = RemoteBlueskyRun

--- a/intake_bluesky/jsonl.py
+++ b/intake_bluesky/jsonl.py
@@ -39,7 +39,7 @@ class _Entries(collections.abc.Mapping):
         return intake.catalog.local.LocalCatalogEntry(
             name=run_start_doc['uid'],
             description={},  # TODO
-            driver='intake_bluesky.core.RunCatalog',
+            driver='intake_bluesky.core.BlueskyRun',
             direct_access='forbid',  # ???
             args=args,
             cache=None,  # ???

--- a/intake_bluesky/mongo_embedded.py
+++ b/intake_bluesky/mongo_embedded.py
@@ -82,7 +82,7 @@ class _Entries(collections.abc.Mapping):
         return intake.catalog.local.LocalCatalogEntry(
             name=run_start_doc['uid'],
             description={},  # TODO
-            driver='intake_bluesky.core.RunCatalog',
+            driver='intake_bluesky.core.BlueskyRun',
             direct_access='forbid',  # ???
             args=args,
             cache=None,  # ???

--- a/intake_bluesky/mongo_normalized.py
+++ b/intake_bluesky/mongo_normalized.py
@@ -38,7 +38,7 @@ class _Entries(collections.abc.Mapping):
         return intake.catalog.local.LocalCatalogEntry(
             name=run_start_doc['uid'],
             description={},  # TODO
-            driver='intake_bluesky.core.RunCatalog',
+            driver='intake_bluesky.core.BlueskyRun',
             direct_access='forbid',  # ???
             args=args,
             cache=None,  # ???

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask[bag]
-event_model >=1.8.0
+event_model >=1.8.0,<1.10.0
 msgpack
 msgpack-numpy
 intake !=0.5.0


### PR DESCRIPTION
It was pointed out by @tacaswell that "RunCatalog" sounds like a
catalog of runs when in fact it is an object embodying *one* run.

This is a semi-internal object, so it is not very disruptive to rename it,
and will hopefully make the library internals easier to follow.