### PR TITLE
ENH: Add read_raw()

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -82,7 +82,7 @@ Read Data as Bluesky "Documents"
 
 .. ipython:: python
 
-   catalog[uid].read_canonical()
+   catalog[uid].canonical()
 
 This generator yields ``(name, doc)`` pairs and can be fed into streaming
 visualization, processing, and serialization tools that consume this

--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -418,12 +418,12 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
     def _close(self):
         self.bag = None
 
-    def read_canonical(self):
+    def canonical(self):
         for i in range(self.npartitions):
             for name, doc in self._get_partition((i, False)):
                 yield name, doc
 
-    def read_raw(self):
+    def canonical_unfilled(self):
         for i in range(self.npartitions):
             for name, doc in self._get_partition((i, True)):
                 yield name, doc
@@ -583,17 +583,17 @@ class BlueskyRun(intake.catalog.Catalog):
                 getshell=True,
                 catalog=self)
 
-    def read_canonical(self):
+    def canonical(self):
         for i in range(self.npartitions):
             for name, doc in self.read_partition((i, False)):
                 yield name, doc
 
-    def read_raw(self):
+    def canonical_unfilled(self):
         for i in range(self.npartitions):
             for name, doc in self.read_partition((i, True)):
                 yield name, doc
 
-    def read_raw_partition(self, i):
+    def read_partition_unfilled(self, i):
         """Fetch one chunk of documents.
         """
         self._load()
@@ -646,7 +646,7 @@ class BlueskyRun(intake.catalog.Catalog):
         """
         i, raw = index
         if raw:
-            return self.read_raw_partition(i)
+            return self.read_partition_unfilled(i)
         self._load()
         payload = []
         start = i * self.PARTITION_SIZE

--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -423,6 +423,12 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
             for name, doc in self._get_partition((i, False)):
                 yield name, doc
 
+    def read_canonical(self):
+        warnings.warn(
+            "The method read_canonical has been renamed canonical. This alias "
+            "may be removed in a future release.")
+        yield from self.canonical()
+
     def canonical_unfilled(self):
         for i in range(self.npartitions):
             for name, doc in self._get_partition((i, True)):

--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -423,6 +423,11 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
             for name, doc in self._get_partition((i, False)):
                 yield name, doc
 
+    def read_raw(self):
+        for i in range(self.npartitions):
+            for name, doc in self._get_partition((i, True)):
+                yield name, doc
+
     def __repr__(self):
         self._load()
         try:

--- a/intake_bluesky/core.py
+++ b/intake_bluesky/core.py
@@ -385,16 +385,25 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
 
     def _load_metadata(self):
         if self.bag is None:
+            self.raw_parts = [dask.delayed(intake.container.base.get_partition)(
+                self.url, self.http_args, self._source_id, self.container, (i, True)
+            )
+                          for i in range(self.npartitions)]
             self.parts = [dask.delayed(intake.container.base.get_partition)(
-                self.url, self.http_args, self._source_id, self.container, i
+                self.url, self.http_args, self._source_id, self.container, (i, False)
             )
                           for i in range(self.npartitions)]
             self.bag = dask.bag.from_delayed(self.parts)
         return self._schema
 
-    def _get_partition(self, i):
+    def _get_partition(self, index):
         self._load_metadata()
-        return self.parts[i].compute()
+        i, raw = index
+        if raw:
+            parts = self.raw_parts
+        else:
+            parts = self.parts
+        return parts[i].compute()
 
     def read(self):
         raise NotImplementedError(
@@ -411,7 +420,7 @@ class RemoteBlueskyRun(intake.catalog.base.RemoteCatalog):
 
     def read_canonical(self):
         for i in range(self.npartitions):
-            for name, doc in self._get_partition(i):
+            for name, doc in self._get_partition((i, False)):
                 yield name, doc
 
     def __repr__(self):
@@ -571,12 +580,63 @@ class BlueskyRun(intake.catalog.Catalog):
 
     def read_canonical(self):
         for i in range(self.npartitions):
-            for name, doc in self.read_partition(i):
+            for name, doc in self.read_partition((i, False)):
                 yield name, doc
 
-    def read_partition(self, i):
+    def read_raw(self):
+        for i in range(self.npartitions):
+            for name, doc in self.read_partition((i, True)):
+                yield name, doc
+
+    def read_raw_partition(self, i):
         """Fetch one chunk of documents.
         """
+        self._load()
+        payload = []
+        start = i * self.PARTITION_SIZE
+        stop = (1 + i) * self.PARTITION_SIZE
+        if start < self._offset:
+            payload.extend(
+                itertools.islice(
+                    itertools.chain(
+                        (('start', self._get_run_start()),),
+                        (('descriptor', doc) for doc in self._descriptors)),
+                    start,
+                    stop))
+        descriptor_uids = [doc['uid'] for doc in self._descriptors]
+        skip = max(0, start - len(payload))
+        limit = stop - start - len(payload)
+        # print('start, stop, skip, limit', start, stop, skip, limit)
+        datum_ids = set()
+        if limit > 0:
+            events = self._get_event_cursor(descriptor_uids=descriptor_uids,
+                                            skip=skip, limit=limit)
+            for event in events:
+                for key, is_filled in event['filled'].items():
+                    if not is_filled:
+                        datum_id = event['data'][key]
+                        if datum_id not in datum_ids:
+                            datum = self._get_datum(datum_id=datum_id)
+                            resource_uid = datum['resource']
+                            resource = self._get_resource(uid=resource_uid)
+                            payload.append(('resource', resource))
+                            for datum in self._get_datum_cursor(resource_uid=resource_uid):
+                                # TODO Greedily cache but lazily emit.
+                                payload.append(('datum', datum))
+                                datum_ids.add(datum['datum_id'])
+                payload.append(('event', event))
+            if i == self.npartitions - 1 and self._run_stop_doc is not None:
+                payload.append(('stop', self._run_stop_doc))
+        for _, doc in payload:
+            doc.pop('_id', None)
+        return payload
+
+    def read_partition(self, index):
+        """Fetch one chunk of documents.
+        """
+        i, raw = index
+        if raw:
+            return self.read_raw_partition(i)
         self._load()
         payload = []
         start = i * self.PARTITION_SIZE

--- a/intake_bluesky/tests/generic.py
+++ b/intake_bluesky/tests/generic.py
@@ -129,6 +129,29 @@ def test_read_canonical(bundle):
             assert numpy.array_equal(actual_doc, expected_doc)
 
 
+def test_read_raw(bundle):
+    run = bundle.cat['xyz']()[bundle.uid]
+    run.read_raw()
+
+    def sorted_actual():
+        for name, doc in bundle.docs:
+            yield name, doc
+    #     for name_ in ('start', 'descriptor', 'resource', 'datum', 'event_page', 'event', 'stop'):
+    #         for name, doc in bundle.docs:
+    #             if name == name_:
+    #                 yield name, doc
+
+    for actual, expected in itertools.zip_longest(
+            run.read_raw(), sorted_actual()):
+        actual_name, actual_doc = actual
+        expected_name, expected_doc = expected
+        print(expected_name)
+        try:
+            assert actual_name == expected_name
+        except ValueError:
+            assert numpy.array_equal(actual_doc, expected_doc)
+
+
 def test_read(bundle):
     run = bundle.cat['xyz']()[bundle.uid]()
     entry = run['primary']

--- a/intake_bluesky/tests/generic.py
+++ b/intake_bluesky/tests/generic.py
@@ -105,7 +105,11 @@ def test_run_metadata(bundle):
 
 def test_canonical(bundle):
     run = bundle.cat['xyz']()[bundle.uid]
-    run.canonical()
+
+    # Smoke test for back-compat alias
+    with pytest.warns(UserWarning):
+        next(run.read_canonical())
+
     filler = event_model.Filler({'NPY_SEQ': ophyd.sim.NumpySeqHandler},
                                 inplace=True)
 

--- a/intake_bluesky/tests/generic.py
+++ b/intake_bluesky/tests/generic.py
@@ -103,10 +103,11 @@ def test_run_metadata(bundle):
         assert key in run().metadata  # datasource
 
 
-def test_read_canonical(bundle):
+def test_canonical(bundle):
     run = bundle.cat['xyz']()[bundle.uid]
-    run.read_canonical()
-    filler = event_model.Filler({'NPY_SEQ': ophyd.sim.NumpySeqHandler}, inplace=True)
+    run.canonical()
+    filler = event_model.Filler({'NPY_SEQ': ophyd.sim.NumpySeqHandler},
+                                inplace=True)
 
     def sorted_actual():
         for name_ in ('start', 'descriptor', 'resource',
@@ -119,7 +120,7 @@ def test_read_canonical(bundle):
                     yield name, filled_doc
 
     for actual, expected in itertools.zip_longest(
-            run.read_canonical(), sorted_actual()):
+            run.canonical(), sorted_actual()):
         actual_name, actual_doc = actual
         expected_name, expected_doc = expected
         print(actual_name, expected_name)
@@ -129,9 +130,9 @@ def test_read_canonical(bundle):
             assert numpy.array_equal(actual_doc, expected_doc)
 
 
-def test_read_raw(bundle):
+def test_read_unfilled(bundle):
     run = bundle.cat['xyz']()[bundle.uid]
-    run.read_raw()
+    run.read_unfilled()
 
     def sorted_actual():
         for name_ in ('start', 'descriptor', 'resource',
@@ -141,7 +142,7 @@ def test_read_raw(bundle):
                                               'event', 'event_page', 'stop'):
                     yield name, doc
 
-    raw_run = [(name, doc) for name, doc in list(run.read_raw())
+    raw_run = [(name, doc) for name, doc in list(run.read_unfilled())
                if name not in ('resource', 'datum', 'datum_page')]
 
     for actual, expected in itertools.zip_longest(
@@ -158,7 +159,7 @@ def test_read_raw(bundle):
     # Passing the run through the filler to check resource and datum are
     # received before corresponding event.
     filler = event_model.Filler({'NPY_SEQ': ophyd.sim.NumpySeqHandler})
-    for name, doc in run.read_raw():
+    for name, doc in run.read_unfilled():
         filler(name, doc)
 
 

--- a/intake_bluesky/tests/generic.py
+++ b/intake_bluesky/tests/generic.py
@@ -130,9 +130,9 @@ def test_canonical(bundle):
             assert numpy.array_equal(actual_doc, expected_doc)
 
 
-def test_read_unfilled(bundle):
+def test_canonical_unfilled(bundle):
     run = bundle.cat['xyz']()[bundle.uid]
-    run.read_unfilled()
+    run.canonical_unfilled()
 
     def sorted_actual():
         for name_ in ('start', 'descriptor', 'resource',
@@ -142,7 +142,7 @@ def test_read_unfilled(bundle):
                                               'event', 'event_page', 'stop'):
                     yield name, doc
 
-    raw_run = [(name, doc) for name, doc in list(run.read_unfilled())
+    raw_run = [(name, doc) for name, doc in list(run.canonical_unfilled())
                if name not in ('resource', 'datum', 'datum_page')]
 
     for actual, expected in itertools.zip_longest(
@@ -159,7 +159,7 @@ def test_read_unfilled(bundle):
     # Passing the run through the filler to check resource and datum are
     # received before corresponding event.
     filler = event_model.Filler({'NPY_SEQ': ophyd.sim.NumpySeqHandler})
-    for name, doc in run.read_unfilled():
+    for name, doc in run.canonical_unfilled():
         filler(name, doc)
 
 

--- a/intake_bluesky/tests/generic.py
+++ b/intake_bluesky/tests/generic.py
@@ -6,6 +6,17 @@ import ophyd.sim
 import pytest
 
 
+def uid_sorted(docs):
+    def key(item):
+        name, doc = item
+        if name == 'datum':
+            return doc['datum_id']
+        else:
+            return doc['uid']
+
+    return sorted(docs, key=key)
+
+
 def test_fixture(bundle):
     "Simply open the Catalog created by the fixture."
 
@@ -133,16 +144,8 @@ def test_read_raw(bundle):
     run = bundle.cat['xyz']()[bundle.uid]
     run.read_raw()
 
-    def sorted_actual():
-        for name, doc in bundle.docs:
-            yield name, doc
-    #     for name_ in ('start', 'descriptor', 'resource', 'datum', 'event_page', 'event', 'stop'):
-    #         for name, doc in bundle.docs:
-    #             if name == name_:
-    #                 yield name, doc
-
     for actual, expected in itertools.zip_longest(
-            run.read_raw(), sorted_actual()):
+            uid_sorted(run.read_raw()), uid_sorted(bundle.docs)):
         actual_name, actual_doc = actual
         expected_name, expected_doc = expected
         print(expected_name)


### PR DESCRIPTION
This adds a method equivalent to `header.documents()` in databroker.

It supports Access Mode (5) in #17 for applications like exporting/migrating
where we want to expose Resource, Datum, and "unfilled" Events.

This should probably be merged after #45, assuming wrap up #45 in the next week
or so, and will need to be reworked to expect `get_event_pages` instead of
`get_events_cursor` and likewise for Datum.