### PR TITLE
TST: Make tests go 7X faster by using module fixtures.

### DIFF
--- a/intake_bluesky/tests/conftest.py
+++ b/intake_bluesky/tests/conftest.py
@@ -1,3 +1,2 @@
 from intake.conftest import intake_server  # noqa
-from suitcase.mongo_normalized.tests.fixtures import db_factory  # noqa
 from .fixtures import *  # noqa

--- a/intake_bluesky/tests/fixtures.py
+++ b/intake_bluesky/tests/fixtures.py
@@ -1,14 +1,42 @@
-from bluesky.tests.conftest import RE  # noqa
+import asyncio
+import uuid
+
+from bluesky.run_engine import RunEngine, TransitionError
 from bluesky.plans import scan
 from bluesky.preprocessors import SupplementalData
 import event_model
 import ophyd.sim
+import pymongo
 import pytest
 
 
-@pytest.fixture
+# Make module-scoped versions of these fixtures to avoid paying for
+# intake-server startup each time.
+
+
+@pytest.fixture(scope='module')
 def hw():
     return ophyd.sim.hw()  # a SimpleNamespace of simulated devices
+
+
+@pytest.fixture(scope='module')
+def RE(request):
+    loop = asyncio.new_event_loop()
+    loop.set_debug(True)
+    RE = RunEngine({}, loop=loop)
+
+    def clean_event_loop():
+        if RE.state not in ('idle', 'panicked'):
+            try:
+                RE.halt()
+            except TransitionError:
+                pass
+        loop.call_soon_threadsafe(loop.stop)
+        RE._th.join()
+        loop.close()
+
+    request.addfinalizer(clean_event_loop)
+    return RE
 
 
 SIM_DETECTORS = {'scalar': 'det',
@@ -16,12 +44,12 @@ SIM_DETECTORS = {'scalar': 'det',
                  'external_image': 'img'}
 
 
-@pytest.fixture(params=['scalar', 'image', 'external_image'])
+@pytest.fixture(params=['scalar', 'image', 'external_image'], scope='module')
 def detector(request, hw):
     return getattr(hw, SIM_DETECTORS[request.param])
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def example_data(hw, detector, RE):  # noqa
     sd = SupplementalData(baseline=[hw.motor])
     RE.preprocessors.append(sd)
@@ -33,3 +61,18 @@ def example_data(hw, detector, RE):  # noqa
 
     uid, = RE(scan([detector], hw.motor, -1, 1, 20), collect)
     return uid, docs
+
+
+@pytest.fixture(scope='module')
+def db_factory(request):
+    def inner():
+        database_name = f'test-{str(uuid.uuid4())}'
+        uri = f'mongodb://localhost:27017/'
+        client = pymongo.MongoClient(uri)
+
+        def drop():
+            client.drop_database(database_name)
+
+        request.addfinalizer(drop)
+        return client[database_name]
+    return inner

--- a/intake_bluesky/tests/fixtures.py
+++ b/intake_bluesky/tests/fixtures.py
@@ -1,6 +1,8 @@
 import asyncio
+from distutils.version import LooseVersion
 import uuid
 
+import bluesky
 from bluesky.run_engine import RunEngine, TransitionError
 from bluesky.plans import scan
 from bluesky.preprocessors import SupplementalData
@@ -32,7 +34,8 @@ def RE(request):
             except TransitionError:
                 pass
         loop.call_soon_threadsafe(loop.stop)
-        RE._th.join()
+        if LooseVersion(bluesky.__version__) >= LooseVersion('1.6.0'):
+            RE._th.join()
         loop.close()
 
     request.addfinalizer(clean_event_loop)

--- a/intake_bluesky/tests/generic.py
+++ b/intake_bluesky/tests/generic.py
@@ -111,7 +111,7 @@ def test_canonical(bundle):
         next(run.read_canonical())
 
     filler = event_model.Filler({'NPY_SEQ': ophyd.sim.NumpySeqHandler},
-                                inplace=True)
+                                inplace=False)
 
     def sorted_actual():
         for name_ in ('start', 'descriptor', 'resource',
@@ -162,7 +162,8 @@ def test_canonical_unfilled(bundle):
 
     # Passing the run through the filler to check resource and datum are
     # received before corresponding event.
-    filler = event_model.Filler({'NPY_SEQ': ophyd.sim.NumpySeqHandler})
+    filler = event_model.Filler({'NPY_SEQ': ophyd.sim.NumpySeqHandler},
+                                inplace=False)
     for name, doc in run.canonical_unfilled():
         filler(name, doc)
 

--- a/intake_bluesky/tests/test_jsonl.py
+++ b/intake_bluesky/tests/test_jsonl.py
@@ -2,6 +2,7 @@ import intake_bluesky.jsonl # noqa
 import intake
 from suitcase.jsonl import Serializer
 import os
+from pathlib import Path
 import pytest
 import shutil
 import tempfile
@@ -10,28 +11,32 @@ import types
 
 from .generic import *  # noqa
 
-TMP_DIR = tempfile.mkdtemp()
-TEST_CATALOG_PATH = [TMP_DIR]
+
+TMP_DIRS = {param: tempfile.mkdtemp() for param in ['local', 'remote']}
+TEST_CATALOG_PATH = TMP_DIRS['remote']  # used by intake_server fixture
 
 YAML_FILENAME = 'intake_test_catalog.yml'
 
 
 def teardown_module(module):
-    try:
-        shutil.rmtree(TMP_DIR)
-    except BaseException:
-        pass
+    for path in TMP_DIRS.values():
+        try:
+            shutil.rmtree(path)
+        except BaseException:
+            pass
 
 
-@pytest.fixture(params=['local', 'remote'])
-def bundle(request, intake_server, example_data, tmp_path):  # noqa
-    serializer = Serializer(tmp_path)
+@pytest.fixture(params=['local', 'remote'], scope='module')
+def bundle(request, intake_server, example_data):  # noqa
+    tmp_dir = TMP_DIRS[request.param]
+    tmp_data_dir = Path(tmp_dir) / 'data'
+    serializer = Serializer(tmp_data_dir)
     uid, docs = example_data
     for name, doc in docs:
         serializer(name, doc)
     serializer.close()
 
-    fullname = os.path.join(TMP_DIR, YAML_FILENAME)
+    fullname = os.path.join(tmp_dir, YAML_FILENAME)
     with open(fullname, 'w') as f:
         f.write(f'''
 plugins:
@@ -53,7 +58,7 @@ sources:
     time.sleep(2)
 
     if request.param == 'local':
-        cat = intake.Catalog(os.path.join(TMP_DIR, YAML_FILENAME))
+        cat = intake.Catalog(os.path.join(tmp_dir, YAML_FILENAME))
     elif request.param == 'remote':
         cat = intake.Catalog(intake_server, page_size=10)
     else:

--- a/intake_bluesky/tests/test_mongo_embedded.py
+++ b/intake_bluesky/tests/test_mongo_embedded.py
@@ -23,7 +23,7 @@ def teardown_module(module):
         pass
 
 
-@pytest.fixture(params=['local', 'remote'])
+@pytest.fixture(params=['local', 'remote'], scope='module')
 def bundle(request, intake_server, example_data, db_factory):  # noqa
     fullname = os.path.join(TMP_DIR, YAML_FILENAME)
     permanent_db = db_factory()

--- a/intake_bluesky/tests/test_mongo_normalized.py
+++ b/intake_bluesky/tests/test_mongo_normalized.py
@@ -23,7 +23,7 @@ def teardown_module(module):
         pass
 
 
-@pytest.fixture(params=['local', 'remote'])
+@pytest.fixture(params=['local', 'remote'], scope='module')
 def bundle(request, intake_server, example_data, db_factory):  # noqa
     fullname = os.path.join(TMP_DIR, YAML_FILENAME)
     mds_db = db_factory()


### PR DESCRIPTION
Locally, pytest runs all the tests in 103s, down from 773s on `master`.

Using function-scoped fixtures gives better isolation between tests.
I believe that function-scope isolation is important for testing
data *writing* (i.e. suitcase) but taht module-scope isolation is
sufficient for reading.

Four tests fail due to a bad interaction related to filling in place.
Those of course need to be fixed before this should be merged.