### PR TITLE
added filename argument to gen

### DIFF
--- a/intake_bluesky/jsonl.py
+++ b/intake_bluesky/jsonl.py
@@ -6,6 +6,13 @@ import pathlib
 from .in_memory import BlueskyInMemoryCatalog
 
 
+def gen(filename):
+    with open(filename, 'r') as file:
+        for line in file:
+            name, doc = json.loads(line)
+            yield (name, doc)
+
+
 class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
     name = 'bluesky-jsonl-catalog'  # noqa
 
@@ -41,11 +48,6 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
                          query=query,
                          **kwargs)
 
-    def gen(filename):
-        with open(filename, 'r') as file:
-            for line in file:
-                name, doc = json.loads(line)
-                yield (name, doc)
 
     def _load(self):
         for path in self.paths:

--- a/intake_bluesky/jsonl.py
+++ b/intake_bluesky/jsonl.py
@@ -41,6 +41,12 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
                          query=query,
                          **kwargs)
 
+    def gen(filename):
+        with open(filename, 'r') as file:
+            for line in file:
+                name, doc = json.loads(line)
+                yield (name, doc)
+
     def _load(self):
         for path in self.paths:
             for filename in glob.glob(path):
@@ -56,13 +62,7 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
                         if not file.readline():
                             # Empty file, maybe being written to currently
                             continue
-
-                def gen():
-                    with open(filename, 'r') as file:
-                        for line in file:
-                            name, doc = json.loads(line)
-                            yield (name, doc)
-                self.upsert(gen, (), {})
+                self.upsert(gen, (filename,), {})
 
     def search(self, query):
         """

--- a/intake_bluesky/jsonl.py
+++ b/intake_bluesky/jsonl.py
@@ -48,7 +48,6 @@ class BlueskyJSONLCatalog(BlueskyInMemoryCatalog):
                          query=query,
                          **kwargs)
 
-
     def _load(self):
         for path in self.paths:
             for filename in glob.glob(path):


### PR DESCRIPTION
this test always passes: `pytest databroker/tests/test_broker.py::test_get_fields[intake_jsonl]`
this failed 50% of the time: `pytest databroker/tests/test_broker.py::test_no_descriptor_name[intake_jsonl] databroker/tests/test_broker.py::test_get_fields[intake_jsonl]`

it was depending on the order that the files were loaded, which depended on the UUID filename.
This PR fixes this issue.